### PR TITLE
Separate CICD workflow into dev and prod workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,24 @@
+name: Dev
+on:
+  push:
+    branches-ignore:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - run: yarn install
+    - run: yarn test
+    - run: yarn run lint
+    - run: yarn dist
+    - name: Deploy branches to Heroku staging environment
+      env:
+        HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
+      run: git push https://heroku:$HEROKU_AUTH_TOKEN@git.heroku.com/create-issue-branch-staging.git origin/${GITHUB_REF##*/}:master
+      if: job.status == 'success' && (! startsWith(github.ref, 'refs/heads/dependabot/'))

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,15 +1,13 @@
-name: CICD
-
-on: [push]
-
+name: Prod
+on: 
+  push:
+    branches:
+      - master
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    
     env:
       CI: true
-      
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
@@ -23,21 +21,16 @@ jobs:
       env:
         HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
       run: git push https://heroku:$HEROKU_AUTH_TOKEN@git.heroku.com/create-issue-branch.git origin/master:master
-      if: github.ref == 'refs/heads/master' && job.status == 'success'
-    - name: Deploy branches to Heroku staging environment
-      env:
-        HEROKU_AUTH_TOKEN: ${{ secrets.HEROKU_AUTH_TOKEN }}
-      run: git push https://heroku:$HEROKU_AUTH_TOKEN@git.heroku.com/create-issue-branch-staging.git origin/${GITHUB_REF##*/}:master
-      if: github.ref != 'refs/heads/master' && job.status == 'success' && (! startsWith(github.ref, 'refs/heads/dependabot/'))
+      if: job.status == 'success'
     - name: Commit GitHub Action distribution
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add dist/index.js
         git commit -m "Build by GitHub Actions" || true
-      if: github.ref == 'refs/heads/master' && job.status == 'success'
+      if: job.status == 'success'
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-      if: github.ref == 'refs/heads/master' && job.status == 'success'
+      if: job.status == 'success'


### PR DESCRIPTION
- Refactored cicd.yml into seperate workflow files for production and development.

- Production script will run only on push to master

- Development script will run on every push to development branches (non master)

- Ensured dependabot branches run and execute tests but are not deployed to Heroku