### PR TITLE
Fix commit message in createPR

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -207,7 +207,7 @@ async function createPR (app, ctx, config, username, branchName) {
   const title = context.getIssueTitle(ctx)
   const issueNumber = context.getIssueNumber(ctx)
   const draft = Config.shouldOpenDraftPR(config)
-  const draftText = draft ? "draft " : ""
+  const draftText = draft ? 'draft ' : ''
   try {
     const commitSha = await getBranchHeadSha(ctx, branchName)
     const treeSha = await getCommitTreeSha(ctx, commitSha)

--- a/src/github.js
+++ b/src/github.js
@@ -207,17 +207,18 @@ async function createPR (app, ctx, config, username, branchName) {
   const title = context.getIssueTitle(ctx)
   const issueNumber = context.getIssueNumber(ctx)
   const draft = Config.shouldOpenDraftPR(config)
+  const draftText = draft ? "draft " : ""
   try {
     const commitSha = await getBranchHeadSha(ctx, branchName)
     const treeSha = await getCommitTreeSha(ctx, commitSha)
-    const emptyCommitSha = await createCommit(ctx, commitSha, treeSha, username, 'Create draft PR')
+    const emptyCommitSha = await createCommit(ctx, commitSha, treeSha, username, `Create ${draftText}PR`)
     await updateReference(ctx, branchName, emptyCommitSha)
     await ctx.octokit.pulls.create(
       { owner, repo, head: branchName, base, title, body: `closes #${issueNumber}`, draft: draft })
     app.log(`Pull request created for branch ${branchName}`)
   } catch (e) {
     app.log(`Could not create draft PR (${e.message})`)
-    await addComment(ctx, config, `Could not create draft PR (${e.message})`)
+    await addComment(ctx, config, `Could not create ${draftText}PR (${e.message})`)
   }
 }
 


### PR DESCRIPTION
Currently, draft and non-draft PRs will get the same commit message 'Create draft PR'. This commit fixes that so that non-draft PRs get the message 'Create PR'.

I've not been able to test this code but I thought it was better to write some code instead of asking you to write the code for me :-)