### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ if not give this App/Action a try.
 
 ## Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=robvanderleek/create-issue-branch&type=Date)](https://star-history.com/#robvanderleek/create-issue-branch&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=robvanderleek/create-issue-branch&type=Date)](https://star-history.dera.page/#robvanderleek/create-issue-branch&Date)
 
 ## Features under consideration
 


### PR DESCRIPTION
The Star History chart in the README is broken because of GitHub stargazer API restrictions that prevent the current provider from fetching data. This PR updates the chart to use a provider that relies on a different data source and requires no API token, so the chart works reliably again.